### PR TITLE
.gitignore fix

### DIFF
--- a/source/propelpals/.gitignore
+++ b/source/propelpals/.gitignore
@@ -27,8 +27,12 @@ platforms/
 plugins/
 plugins/android.json
 plugins/ios.json
+www/*
 $RECYCLE.BIN/
 
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+
+# Whitelist www/aframe
+!www/aframe


### PR DESCRIPTION
ignoring all files and folders in www, except for aframe necessary for augmented reality.